### PR TITLE
Fix initial "It works!" page so that it loads correctly

### DIFF
--- a/templates/app/public/index.html
+++ b/templates/app/public/index.html
@@ -17,6 +17,5 @@
   <!-- Getting started script - should be removed -->
   <script src="http://maccman-spine.herokuapp.com/start.js" type="text/javascript" charset="utf-8"></script>
 </head>
-<body>
-</body>
+<body></body>
 </html>


### PR DESCRIPTION
The Heroku script looks for body content that is "\n\n" but the line break makes the body content "\n\n\n" so I was seeing a blank screen.
