### PR TITLE
Change semicolons to commas in viewport meta tag content properties list

### DIFF
--- a/templates/mobile/public/index.html
+++ b/templates/mobile/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset=utf-8>
   <title>App</title>
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; minimum-scale=1; maximum-scale=1.0; user-scalable=0;"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1.0, user-scalable=0"/>
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="format-detection" content="telephone=no" />
   


### PR DESCRIPTION
Viewport values should be separated by commas. Chrome and Safari both generate errors/warnings and ignore the values if characters other than comma are used.
