### PR TITLE
Fix for Error: Cannot find module '../src/template'

### DIFF
--- a/bin/spine
+++ b/bin/spine
@@ -4,6 +4,7 @@ var argv = process.argv.slice(2),
     fd   = require("path");
 
 var cs       = require("coffee-script");
+if (cs.register) cs.register(); // so we can require .coffee files
 var Template = require("../src/template");
 
 var expandPath = function(path, dir){


### PR DESCRIPTION
Fix for "Error: Cannot find module '../src/template'" since CoffeeScript >= v1.7.0 broke automatic requiring of .coffee files.

See change log for CoffeeScript v1.7.0 (at bottom of http://coffeescript.org/) for more details.

To reproduce the bug: `rm -rf node_modules/coffee-script; npm install; bin/spine`
