### PR TITLE
Update package.json template to reference es5-shimify instead of es5-shim

### DIFF
--- a/templates/app/package.json
+++ b/templates/app/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "es5-shimify": "~2.3.0",
     "json2ify": "~0.0.4",
-    "jqueryify": "~1.11.0",
-    "spine": "~1.2.2"
+    "jqueryify": "~2.1.0",
+    "spine": "~1.3.0"
   }
 }


### PR DESCRIPTION
Setting up a new project with spine.app I was getting an error because es5-shimify was not installed as referenced in lib/setup.coffee and slug.json. I updated the reference in the package.json template accordingly.

Was this change correct or should lib/setup.coffee and slug.json be referencing es5-shim instead?

Also bumped up the version numbers in the package.json template.
